### PR TITLE
feat(go-cwl): add /version endpoint to webhook server

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"crypto/tls"
 	"flag"
+	"net/http"
 	"os"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -37,6 +38,7 @@ import (
 
 	gastownv1alpha1 "github.com/org/gastown-operator/api/v1alpha1"
 	"github.com/org/gastown-operator/internal/controller"
+	"github.com/org/gastown-operator/pkg/version"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -123,6 +125,9 @@ func main() {
 		}
 
 		webhookServer = webhook.NewServer(webhookServerOptions)
+
+		// Register /version endpoint on the webhook server
+		webhookServer.Register("/version", http.HandlerFunc(version.Handler()))
 	} else {
 		setupLog.Info("Webhooks disabled via --disable-webhooks flag")
 	}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package version provides version information for the operator.
+package version
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// These variables are set at build time via -ldflags.
+var (
+	// Version is the operator version.
+	Version = "0.1.0"
+	// Commit is the git commit hash.
+	Commit = "unknown"
+	// BuildTime is the build timestamp.
+	BuildTime = "unknown"
+)
+
+// Info contains version information.
+type Info struct {
+	Version   string `json:"version"`
+	Commit    string `json:"commit"`
+	BuildTime string `json:"buildTime"`
+}
+
+// Get returns the current version info.
+func Get() Info {
+	return Info{
+		Version:   Version,
+		Commit:    Commit,
+		BuildTime: BuildTime,
+	}
+}
+
+// Handler returns an http.HandlerFunc that serves version info as JSON.
+func Handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(Get())
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `/version` endpoint to the operator webhook server
- Returns JSON with version, commit, and build time
- Values can be set via `-ldflags` at build time

## Changes
- Created `pkg/version/version.go` with version info handling
- Modified `cmd/main.go` to register the endpoint

## Issue
Implements go-cwl

## E2E Proof
This PR was created by a Gas Town polecat worker running in OpenShift.
The operator successfully dispatched the task, Claude implemented it, and pushed the branch.